### PR TITLE
fix: inform heroku where to start the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
+    "start": "src/bin/start-server.js",
     "start-dev-server": "nodemon src/bin/start-server.js --color"
   },
   "dependencies": {


### PR DESCRIPTION
- open a pull request to test the `heroku-deploy-to-staging` pipeline
- add `start` command to inform heroku where to launch the app